### PR TITLE
call get_wch instead of getch

### DIFF
--- a/ncurses.cc
+++ b/ncurses.cc
@@ -2091,21 +2091,21 @@ class Window : public ObjectWrap {
         return;
 
       if (revents & EV_READ) {
-        int chr;
-        char tmp[2];
+        wint_t rtn;
+        uint16_t tmp[2];
         tmp[1] = 0;
-        while ((chr = getch()) != ERR) {
+        while (get_wch(&rtn) != ERR) {
           // 410 == KEY_RESIZE
-          if (chr == 410 || !topmost_panel || !topmost_panel->getWindow() || !topmost_panel->getPanel()) {
+          if (rtn == 410 || !topmost_panel || !topmost_panel->getWindow() || !topmost_panel->getPanel()) {
             //if (chr != 410)
             //  ungetch(chr);
             return;
           }
-          tmp[0] = chr;
+          tmp[0] = rtn;
           Local<Value> vChr[3];
           vChr[0] = String::New("inputChar");
           vChr[1] = String::New(tmp);
-          vChr[2] = Integer::New(chr);
+          vChr[2] = Integer::New(rtn);
           Local<Value> emit_v = topmost_panel->getWindow()->handle_->Get(emit_symbol);
           if (!emit_v->IsFunction()) return;
           Local<Function> emit = Local<Function>::Cast(emit_v);


### PR DESCRIPTION
get_wch is required to support multi-byte unicode character input.

This is a example code:

```
var nc=require('../ncurses'),
    sl=require('setlocale');
sl.setlocale(sl.LC_ALL, ''); // must first.

var w = new nc.Window(),
    buf = '',
    tmo;

process.on('SIGINT', function () {
    nc.cleanup();
    console.log(buf);
    process.exit();
});
w.on('inputChar', function(c, x) {
    buf += c;

    w.clear();
    w.cursor(0,0);
    w.addstr(buf);
    w.cursor(w.height-1,0);
    w.addstr(''+x);
    w.refresh();
});
w.refresh();
tmo = setTimeout(function() { w.close(); }, 10*1000);
```

Notes:
ncurses requires setlocale(3) to support unicode. node's setlocale module is a simple wrapper for setlocale(3).
