### PR TITLE
s/ncurses/binding/ for NODE_MODULE() macro call

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2319,5 +2319,5 @@ extern "C" {
     Window::Initialize(target);
   }
 
-  NODE_MODULE(ncurses, init);
+  NODE_MODULE(binding, init);
 }


### PR DESCRIPTION
Which fixes issue where the binding_module symbol cannot be found.

Signed-off-by: Tim Smart tim@fostle.com
