### PR TITLE
Fixed ListBox selection when using multi

### DIFF
--- a/lib/widgets.js
+++ b/lib/widgets.js
@@ -757,6 +757,7 @@ exports.ListBox = function(items, options, cb, cbHover, cbSelect) {
               val = val[0];
             if (values)
               val = values[x];
+            return val;
           });
           if (!selection.length)
             selection = undefined;


### PR DESCRIPTION
An Array.map callback was missing a return statement. The selection returned to the user was always an array of undefined values.
